### PR TITLE
Mobile Audio Fix, part 2

### DIFF
--- a/ilusiv.io/src/app/components/ChuckButton.tsx
+++ b/ilusiv.io/src/app/components/ChuckButton.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import PlayButton, { PlayState } from "./PlayButton";
 import { Chuck } from "webchuck";
+import { getMediaAudioContext, getMediaSinkNode } from "../lib/iosUnmute";
 
 type ChuckButtonProps = {
   code: string;
@@ -24,8 +25,16 @@ const ChuckButton = ({ code }: ChuckButtonProps) => {
     setPrevBtnState(btnState);
 
     const controlChuck = async () => {
-      let chuckRef = chuck ?? (await Chuck.init([]));
-      if (!chuck) {
+      let chuckRef = chuck;
+      if (!chuckRef) {
+        const mediaCtx = getMediaAudioContext();
+        const sinkNode = getMediaSinkNode();
+        chuckRef = mediaCtx
+          ? await Chuck.init([], mediaCtx)
+          : await Chuck.init([]);
+        if (mediaCtx && sinkNode) {
+          (chuckRef as unknown as AudioNode).connect(sinkNode);
+        }
         setChuck(chuckRef);
       }
 

--- a/ilusiv.io/src/app/components/PlayButton.tsx
+++ b/ilusiv.io/src/app/components/PlayButton.tsx
@@ -10,23 +10,60 @@ export enum PlayState {
 
 type PlayButtonProps = {
   onStateChanged: (state: PlayState) => void;
+  title?: string;
+  artist?: string;
 };
 
-const PlayButton = ({ onStateChanged }: PlayButtonProps) => {
+const PlayButton = ({
+  onStateChanged,
+  title = "Music Box",
+  artist = "ilusiv",
+}: PlayButtonProps) => {
   const [btnState, setBtnState] = useState(PlayState.NOT_PLAYING);
 
-  const onBtnClick = () => {
+  const toggle = () => {
     primeMediaAudio();
-    const nextState =
-      btnState === PlayState.PLAYING
-        ? PlayState.NOT_PLAYING
-        : PlayState.PLAYING;
-    setBtnState(nextState);
+    setBtnState((s) =>
+      s === PlayState.PLAYING ? PlayState.NOT_PLAYING : PlayState.PLAYING,
+    );
   };
+
+  const onBtnClick = () => toggle();
 
   useEffect(() => {
     onStateChanged(btnState);
   }, [btnState, onStateChanged]);
+
+  useEffect(() => {
+    if (typeof navigator === "undefined" || !("mediaSession" in navigator)) {
+      return;
+    }
+    const ms = navigator.mediaSession;
+    ms.metadata = new window.MediaMetadata({ title, artist });
+    const handler = () => toggle();
+    try {
+      ms.setActionHandler("play", handler);
+      ms.setActionHandler("pause", handler);
+    } catch {
+      // unsupported action — ignore
+    }
+    return () => {
+      try {
+        ms.setActionHandler("play", null);
+        ms.setActionHandler("pause", null);
+      } catch {
+        // ignore
+      }
+    };
+  }, [title, artist]);
+
+  useEffect(() => {
+    if (typeof navigator === "undefined" || !("mediaSession" in navigator)) {
+      return;
+    }
+    navigator.mediaSession.playbackState =
+      btnState === PlayState.PLAYING ? "playing" : "paused";
+  }, [btnState]);
 
   return (
     <div

--- a/ilusiv.io/src/app/components/PlayButton.tsx
+++ b/ilusiv.io/src/app/components/PlayButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { unmuteIosAudio } from "../lib/iosUnmute";
+import { primeMediaAudio } from "../lib/iosUnmute";
 
 export enum PlayState {
   NOT_PLAYING,
@@ -16,7 +16,7 @@ const PlayButton = ({ onStateChanged }: PlayButtonProps) => {
   const [btnState, setBtnState] = useState(PlayState.NOT_PLAYING);
 
   const onBtnClick = () => {
-    unmuteIosAudio();
+    primeMediaAudio();
     const nextState =
       btnState === PlayState.PLAYING
         ? PlayState.NOT_PLAYING

--- a/ilusiv.io/src/app/lib/iosUnmute.ts
+++ b/ilusiv.io/src/app/lib/iosUnmute.ts
@@ -1,30 +1,56 @@
-// Routes Web Audio output through the iOS "media" channel so it stays
-// audible when the hardware silent switch is on. Works by playing a
-// silent, looping <audio> element with playsinline set, from a user
-// gesture. WebKit then classifies the page as media playback and the
-// AudioContext piggybacks on that routing.
+// Routes Web Audio output through a MediaStream piped into an
+// <audio playsinline> element. iOS classifies that as media playback,
+// so output stays audible when the hardware silent switch is on.
+//
+// Usage:
+//   1. Call primeMediaAudio() synchronously from the user gesture (e.g. click).
+//   2. Pass getMediaAudioContext() to Chuck.init as the AudioContext.
+//   3. Connect Chuck to getMediaSinkNode() instead of ctx.destination.
 
-let unmuteEl: HTMLAudioElement | null = null;
+type Sink = {
+  ctx: AudioContext;
+  dest: MediaStreamAudioDestinationNode;
+  el: HTMLAudioElement;
+};
 
-// 0.04s of silence as a WAV data URL.
-const SILENT_WAV =
-  "data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQAAAAA=";
+let sink: Sink | null = null;
 
-export function unmuteIosAudio(): void {
-  if (typeof window === "undefined") return;
-  if (unmuteEl) {
-    void unmuteEl.play().catch(() => {});
-    return;
-  }
+function ensureSink(): Sink | null {
+  if (typeof window === "undefined") return null;
+  if (sink) return sink;
+
+  const Ctor: typeof AudioContext =
+    window.AudioContext ||
+    (window as unknown as { webkitAudioContext: typeof AudioContext })
+      .webkitAudioContext;
+  if (!Ctor) return null;
+
+  const ctx = new Ctor();
+  const dest = ctx.createMediaStreamDestination();
 
   const el = document.createElement("audio");
   el.setAttribute("playsinline", "");
   el.setAttribute("webkit-playsinline", "");
   (el as HTMLAudioElement & { playsInline?: boolean }).playsInline = true;
-  el.loop = true;
-  el.preload = "auto";
-  el.src = SILENT_WAV;
-  unmuteEl = el;
+  el.autoplay = true;
+  el.srcObject = dest.stream;
 
-  void el.play().catch(() => {});
+  sink = { ctx, dest, el };
+  return sink;
+}
+
+// Must be called from a synchronous user-gesture handler.
+export function primeMediaAudio(): void {
+  const s = ensureSink();
+  if (!s) return;
+  void s.ctx.resume().catch(() => {});
+  void s.el.play().catch(() => {});
+}
+
+export function getMediaAudioContext(): AudioContext | null {
+  return ensureSink()?.ctx ?? null;
+}
+
+export function getMediaSinkNode(): MediaStreamAudioDestinationNode | null {
+  return ensureSink()?.dest ?? null;
 }


### PR DESCRIPTION
### Summary

- Use a silent audio snippet to activate an audio session, and them hand it off to WebChuck. This allow audio playback when iOS is in silent mode.
- Wire up the session to the media player so it appears on the lock screen.